### PR TITLE
Version 2.1.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 #### 2.x Releases
+- `2.1.0` Releases - [2.1.0](#210)
 - `2.0.0` Releases - [2.0.0](#200)
 
 #### 1.x Releases
@@ -9,6 +10,16 @@ All notable changes to this project will be documented in this file.
 - `1.2.0` Releases - [1.2.0](#120)
 - `1.1.0` Releases - [1.1.0](#110)
 - `1.0.x` Releases - [1.0.0](#100) | [1.0.1](#101)
+
+## [2.1.0](https://github.com/skladek/SKImageCache/releases/tag/2.1.0)
+
+#### Added
+- Images can be saved to a path including their url path. This is useful for situations where a server returns images with the same name but a different path. For instance, take following URLs:
+```
+    http://example.com/folder1/image.jpg
+    http://example.com/folder2/image.jpg
+```
+- The first URL will be saved locally at `Documents/folder1/image.jpg` the second will be saved locally at `Documents/folder2/image.jpg`. The key for each will be `folder1/image.jpg` and `folder2/image.jpg` respectively. This allows images with the same lastPathComponent to be used in the same cache.
 
 ## [2.0.0](https://github.com/skladek/SKImageCache/releases/tag/2.0.0)
 

--- a/SKImageCache.podspec
+++ b/SKImageCache.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'SKImageCache'
-  spec.version = '2.0.0'
+  spec.version = '2.1.0'
   spec.license = 'MIT'
   spec.summary = 'A simple image cache.'
   spec.homepage = 'https://github.com/skladek/SKImageCache'

--- a/SampleProject/SampleProject/Application/AppDelegate.swift
+++ b/SampleProject/SampleProject/Application/AppDelegate.swift
@@ -15,6 +15,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
 
+        ImageCache.shared.useURLPathing = true
+        ImageCache.shared.useLocalStorage = true
+
         #if arch(i386) || arch(x86_64)
             if let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.path {
                 print("Documents Directory: \(documentsPath)")

--- a/Source/DataWriter.swift
+++ b/Source/DataWriter.swift
@@ -12,13 +12,19 @@ class DataWriter: DataWriterProtocol {
     }
 
     func writeData(_ data: Data?, fileName: String, directory: String?) {
+        var mutableDirectory = directory
+
+        while mutableDirectory?.range(of: "//") != nil {
+            mutableDirectory = mutableDirectory?.replacingOccurrences(of: "//", with: "/")
+        }
+
         guard let data = data,
-            let directoryPath = pathConstructor.directoryPathString(directory) else {
+            let directoryPath = pathConstructor.directoryPathString(mutableDirectory) else {
                 return
         }
 
         pathConstructor.createDirectoryIfNecessary(path: directoryPath)
-        if let filePath = pathConstructor.filePathURL(fileName, directory: directory) {
+        if let filePath = pathConstructor.filePathURL(fileName, directory: mutableDirectory) {
             try? data.write(to: filePath)
         }
     }

--- a/Source/DataWriter.swift
+++ b/Source/DataWriter.swift
@@ -11,20 +11,26 @@ class DataWriter: DataWriterProtocol {
         self.pathConstructor = pathConstructor
     }
 
-    func writeData(_ data: Data?, fileName: String, directory: String?) {
+    func trimDirectory(_ directory: String?) -> String? {
         var mutableDirectory = directory
 
         while mutableDirectory?.range(of: "//") != nil {
             mutableDirectory = mutableDirectory?.replacingOccurrences(of: "//", with: "/")
         }
 
+        return mutableDirectory
+    }
+
+    func writeData(_ data: Data?, fileName: String, directory: String?) {
+        let trimmedDirectory = trimDirectory(directory)
+
         guard let data = data,
-            let directoryPath = pathConstructor.directoryPathString(mutableDirectory) else {
+            let directoryPath = pathConstructor.directoryPathString(trimmedDirectory) else {
                 return
         }
 
         pathConstructor.createDirectoryIfNecessary(path: directoryPath)
-        if let filePath = pathConstructor.filePathURL(fileName, directory: mutableDirectory) {
+        if let filePath = pathConstructor.filePathURL(fileName, directory: trimmedDirectory) {
             try? data.write(to: filePath)
         }
     }

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -36,6 +36,15 @@ public class ImageCache {
     /// in addition to being available in the cache. If false, files will only be added to the cache.
     public var useLocalStorage: Bool = false
 
+    /// Provides an option to utilize the path provided in the url for file storage. If this is set to yes, any folder structure specified
+    /// in the URL past the base URL will be appended onto any provided directory settings. This is useful in situations where the file
+    /// names are not guaranteed to be unique, but the URLs leading to them are.
+    public var useURLPathing: Bool = false
+
+    // MARK: Internal Types
+
+    typealias ImageInfo = (imageKey: AnyObject, imageName: AnyObject, path: AnyObject?)
+
     // MARK: Internal Variables
 
     let cache: NSCache<AnyObject, UIImage>
@@ -62,16 +71,19 @@ public class ImageCache {
     ///   - url: The image's remote path
     ///   - directory: The directory to save the image in if useLocalStorage is set to true.
     public func cacheImage(_ image: UIImage?, forURL url: URL, directory: String? = nil) {
+        let imageInfo = imageInfoFromURL(url)
+
         guard let image = image,
-            let fileName = imageNameFromURL(url) as? String else {
+            let imageKey = imageInfo.imageKey as? String else {
             return
         }
 
         if useLocalStorage == true {
-            localImageController.savePNG(image, fileName: fileName, directory: directory)
+            let appendedDirectory = concatImageInfoAndDirectory(imageInfo: imageInfo, directory: directory)
+            localImageController.savePNG(image, fileName: imageKey, directory: appendedDirectory)
         }
 
-        cache.setObject(image, forKey: fileName as AnyObject)
+        cache.setObject(image, forKey: imageKey as AnyObject)
     }
 
     /// Deletes the folder at the provided path.
@@ -95,15 +107,19 @@ public class ImageCache {
     ///   - completion: The image, a boolean indicating true if the image was retrieved from the cache, and an error.
     /// - Returns: An optional data task if the image is retrieved from the remote source.
     public func getImage(url: URL, directory: String? = nil, skipCache: Bool = false, completion: @escaping ImageCompletion) -> URLSessionDataTask? {
-        if let image = retrieveFromCache(url: url), skipCache == false {
+        if let image = retrieveFromCache(url: url),
+            skipCache == false {
             completion(image, .cache, nil)
             return nil
         }
 
+        let imageInfo = imageInfoFromURL(url)
+        let concatenatedDirectory = concatImageInfoAndDirectory(imageInfo: imageInfo, directory: directory)
+
         if useLocalStorage == true,
             skipCache == false,
-            let fileName = imageNameFromURL(url) as? String,
-            let image = localImageController.getImage(imageName: fileName, directory: directory) {
+            let fileName = imageInfo.imageKey as? String,
+            let image = localImageController.getImage(imageName: fileName, directory: concatenatedDirectory) {
             completion(image, .localStorage, nil)
             return nil
         }
@@ -118,18 +134,33 @@ public class ImageCache {
     ///
     /// - Parameter url: The URL of the image to remove.
     public func removeObjectAtURL(_ url: URL) {
-        let imageName = imageNameFromURL(url)
-        cache.removeObject(forKey: imageName)
+        let imageInfo = imageInfoFromURL(url)
+        let imageKey = imageInfo.imageKey
+        cache.removeObject(forKey: imageKey)
+    }
+
+    // MARK: Instance Methods
+
+    func concatImageInfoAndDirectory(imageInfo: ImageInfo, directory: String?) -> String {
+        return "\(directory ?? "")\(imageInfo.path as? String ?? "")"
+    }
+
+    func imageInfoFromURL(_ url: URL) -> ImageInfo {
+        if useURLPathing == true {
+            let urlPath = url.path
+            let lastPathComponent = url.lastPathComponent
+            let adjustedURLPath = urlPath.replacingOccurrences(of: lastPathComponent, with: "")
+
+            return (imageKey: urlPath as AnyObject, imageName: lastPathComponent as AnyObject, path: adjustedURLPath as AnyObject)
+        }
+
+        return (imageKey: url.lastPathComponent as AnyObject, imageName: url.lastPathComponent as AnyObject, path: nil)
     }
 
     // MARK: Private Methods
 
-    private func imageNameFromURL(_ url: URL) -> AnyObject {
-        return url.lastPathComponent as AnyObject
-    }
-
     private func retrieveFromCache(url: URL) -> UIImage? {
-        let imageName = imageNameFromURL(url)
-        return cache.object(forKey: imageName)
+        let imageInfo = imageInfoFromURL(url)
+        return cache.object(forKey: imageInfo.imageKey)
     }
 }

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -74,13 +74,14 @@ public class ImageCache {
         let imageInfo = imageInfoFromURL(url)
 
         guard let image = image,
-            let imageKey = imageInfo.imageKey as? String else {
+            let imageKey = imageInfo.imageKey as? String,
+            let imageName = imageInfo.imageName as? String else {
             return
         }
 
         if useLocalStorage == true {
             let appendedDirectory = concatImageInfoAndDirectory(imageInfo: imageInfo, directory: directory)
-            localImageController.savePNG(image, fileName: imageKey, directory: appendedDirectory)
+            localImageController.savePNG(image, fileName: imageName, directory: appendedDirectory)
         }
 
         cache.setObject(image, forKey: imageKey as AnyObject)

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Source/PathConstructor.swift
+++ b/Source/PathConstructor.swift
@@ -27,7 +27,7 @@ class PathConstructor: PathConstructorProtocol {
             return
         }
 
-        try? fileManager.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
+        try? fileManager.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
     }
 
     func directoryPathString(_ directory: String?) -> String? {

--- a/Source/UIImageView.swift
+++ b/Source/UIImageView.swift
@@ -57,6 +57,8 @@ public extension UIImageView {
             return
         }
 
+        print(source)
+
         if source == .remote {
             imageHandler.dissolveToImage(image, onView: self)
         } else {

--- a/Source/UIImageView.swift
+++ b/Source/UIImageView.swift
@@ -57,8 +57,6 @@ public extension UIImageView {
             return
         }
 
-        print(source)
-
         if source == .remote {
             imageHandler.dissolveToImage(image, onView: self)
         } else {

--- a/Tests/DataWriterSpec.swift
+++ b/Tests/DataWriterSpec.swift
@@ -15,6 +15,28 @@ class DataWriterSpec: QuickSpec {
                 unitUnderTest = DataWriter(pathConstructor: pathConstructor)
             }
 
+            context("trimDirectory(_:)") {
+                it("Should replace instances of // in the directory with a single /") {
+                    let inputString = "folder1//folder2//folder3//folder4"
+                    let output = unitUnderTest.trimDirectory(inputString)
+
+                    expect(output).to(equal("folder1/folder2/folder3/folder4"))
+                }
+
+                it("Should return the input string if no instances of // are found") {
+                    let inputString = "folder1/folder2/folder3/folder4"
+                    let output = unitUnderTest.trimDirectory(inputString)
+
+                    expect(output).to(equal(inputString))
+                }
+
+                it("Should return nil if the input is nil") {
+                    let output = unitUnderTest.trimDirectory(nil)
+
+                    expect(output).to(beNil())
+                }
+            }
+
             context("writeData(_:fileName:directory:)") {
                 it("Should not call createDirectoryIfNeeded if data is nil") {
                     unitUnderTest.writeData(nil, fileName: "Test", directory: nil)

--- a/Tests/ImageCacheSpec.swift
+++ b/Tests/ImageCacheSpec.swift
@@ -150,14 +150,16 @@ class ImageCacheSpec: QuickSpec {
             context("imageNameFromURL(_:)") {
                 it("Should return the last path component if useURLPathing is false") {
                     unitUnderTest.useURLPathing = false
-                    let imageName = unitUnderTest.imageNameFromURL(url)
+                    let imageInfo = unitUnderTest.imageInfoFromURL(url)
+                    let imageName = imageInfo.imageKey
 
                     expect((imageName as! String)).to(equal("image1.png"))
                 }
 
                 it("Should return the full image path if useURLPathing is false") {
                     unitUnderTest.useURLPathing = true
-                    let imageName = unitUnderTest.imageNameFromURL(url)
+                    let imageInfo = unitUnderTest.imageInfoFromURL(url)
+                    let imageName = imageInfo.imageKey
 
                     expect((imageName as! String)).to(equal("/folder1/folder2/image1.png"))
                 }

--- a/Tests/ImageCacheSpec.swift
+++ b/Tests/ImageCacheSpec.swift
@@ -17,7 +17,7 @@ class ImageCacheSpec: QuickSpec {
                 delegate = MockImageCacheDelegate()
                 mockLocalImageController = MockLocalImageController()
                 mockNSCache = MockNSCache()
-                url = URL(string: "http://example.url/image1.png")!
+                url = URL(string: "http://example.com/folder1/folder2/image1.png")!
                 unitUnderTest = ImageCache(cache: mockNSCache, localFileController: mockLocalImageController)
                 unitUnderTest.delegate = delegate
             }
@@ -144,6 +144,22 @@ class ImageCacheSpec: QuickSpec {
                     let _ = unitUnderTest.getImage(url: url, directory: nil, skipCache: false, completion: { (_, source, _) in
                         expect(source).to(equal(.localStorage))
                     })
+                }
+            }
+
+            context("imageNameFromURL(_:)") {
+                it("Should return the last path component if useURLPathing is false") {
+                    unitUnderTest.useURLPathing = false
+                    let imageName = unitUnderTest.imageNameFromURL(url)
+
+                    expect((imageName as! String)).to(equal("image1.png"))
+                }
+
+                it("Should return the full image path if useURLPathing is false") {
+                    unitUnderTest.useURLPathing = true
+                    let imageName = unitUnderTest.imageNameFromURL(url)
+
+                    expect((imageName as! String)).to(equal("/folder1/folder2/image1.png"))
                 }
             }
 


### PR DESCRIPTION
#### Added
- Images can be saved to a path including their url path. This is useful for situations where a server returns images with the same name but a different path. For instance, take following URLs:
```
    http://example.com/folder1/image.jpg
    http://example.com/folder2/image.jpg
```
- The first URL will be saved locally at `Documents/folder1/image.jpg` the second will be saved locally at `Documents/folder2/image.jpg`. The key for each will be `folder1/image.jpg` and `folder2/image.jpg` respectively. This allows images with the same lastPathComponent to be used in the same cache.